### PR TITLE
Add whitelist/blacklist feature for domain-specific control

### DIFF
--- a/disable.js
+++ b/disable.js
@@ -16,26 +16,72 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-window.addEventListener(
-	"visibilitychange",
-	function (event) {
-		event.stopImmediatePropagation();
-	},
-	true
-);
+// check if the current URL matches any of the regex patterns
+function matchesPatterns(url, patterns) {
+	for (const pattern of patterns) {
+		try {
+			const regex = new RegExp(pattern);
+			if (regex.test(url)) {
+				return true;
+			}
+		} catch (e) {
+			// invalid regex pattern, skip it
+			console.error('Invalid regex pattern:', pattern, e);
+		}
+	}
+	return false;
+}
 
-window.addEventListener(
-	"webkitvisibilitychange",
-	function (event) {
-		event.stopImmediatePropagation();
-	},
-	true
-);
+// apply the visibility API blocking
+function applyBlocking() {
+	window.addEventListener(
+		"visibilitychange",
+		function (event) {
+			event.stopImmediatePropagation();
+		},
+		true
+	);
 
-window.addEventListener(
-	"blur",
-	function (event) {
-		event.stopImmediatePropagation();
-	},
-	true
-);
+	window.addEventListener(
+		"webkitvisibilitychange",
+		function (event) {
+			event.stopImmediatePropagation();
+		},
+		true
+	);
+
+	window.addEventListener(
+		"blur",
+		function (event) {
+			event.stopImmediatePropagation();
+		},
+		true
+	);
+}
+
+// load settings and apply blocking if needed
+chrome.storage.sync.get({
+	mode: 'all',
+	patterns: []
+}, function(items) {
+	const currentUrl = window.location.href;
+	const mode = items.mode;
+	const patterns = items.patterns;
+	
+	let shouldApply = false;
+	
+	if (mode === 'all') {
+		// apply to all websites
+		shouldApply = true;
+	} else if (mode === 'whitelist') {
+		// only apply if URL matches one of the patterns
+		shouldApply = matchesPatterns(currentUrl, patterns);
+	} else if (mode === 'blacklist') {
+		// apply unless URL matches one of the patterns
+		shouldApply = !matchesPatterns(currentUrl, patterns);
+	}
+	
+	if (shouldApply) {
+		applyBlocking();
+	}
+});

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,11 @@
 	"version": "1.0.3",
 	"author": "Marvin Schopf",
 	"description": "Prevent websites from tracking whether you are currently in another tab/ window.",
+	"permissions": ["storage"],
+	"options_ui": {
+		"page": "options.html",
+		"open_in_tab": true
+	},
 	"content_scripts": [
 		{
 			"matches": ["*://*/*"],

--- a/options.css
+++ b/options.css
@@ -1,0 +1,128 @@
+/**
+ * Disable Page Visibility API - Options Page Styles
+ */
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f5f5f5;
+    color: #333;
+}
+
+.container {
+    max-width: 600px;
+    margin: 40px auto;
+    padding: 30px;
+    background-color: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+h1 {
+    margin-top: 0;
+    margin-bottom: 30px;
+    font-size: 24px;
+    color: #2c3e50;
+}
+
+h2 {
+    margin-top: 30px;
+    margin-bottom: 15px;
+    font-size: 18px;
+    color: #34495e;
+}
+
+.mode-selection {
+    margin-bottom: 30px;
+}
+
+.mode-selection label {
+    display: block;
+    margin-bottom: 10px;
+    padding: 10px 15px;
+    background-color: #f8f9fa;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.mode-selection label:hover {
+    background-color: #e9ecef;
+}
+
+.mode-selection input[type="radio"] {
+    margin-right: 10px;
+}
+
+.patterns-section {
+    margin-bottom: 30px;
+}
+
+.info {
+    margin-bottom: 10px;
+    color: #6c757d;
+    font-size: 14px;
+}
+
+.examples {
+    margin-bottom: 15px;
+    padding-left: 20px;
+    font-size: 14px;
+    color: #6c757d;
+}
+
+.examples code {
+    background-color: #f1f3f4;
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-family: 'Consolas', 'Monaco', monospace;
+    font-size: 13px;
+}
+
+textarea {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    font-family: 'Consolas', 'Monaco', monospace;
+    font-size: 14px;
+    resize: vertical;
+    box-sizing: border-box;
+}
+
+textarea:focus {
+    outline: none;
+    border-color: #4CAF50;
+    box-shadow: 0 0 0 2px rgba(76, 175, 80, 0.1);
+}
+
+.button-group {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+button {
+    padding: 10px 20px;
+    background-color: #4CAF50;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    font-size: 16px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+button:hover {
+    background-color: #45a049;
+}
+
+button:active {
+    background-color: #3d8b40;
+}
+
+#status {
+    font-size: 14px;
+    font-weight: 500;
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Disable Page Visibility API - Options</title>
+    <link rel="stylesheet" href="options.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Disable Page Visibility API - Settings</h1>
+        
+        <div class="mode-selection">
+            <h2>Mode</h2>
+            <label>
+                <input type="radio" name="mode" value="all" id="mode-all" checked>
+                <span>Apply to all websites (default)</span>
+            </label>
+            <label>
+                <input type="radio" name="mode" value="whitelist" id="mode-whitelist">
+                <span>Apply only to websites matching patterns below (whitelist)</span>
+            </label>
+            <label>
+                <input type="radio" name="mode" value="blacklist" id="mode-blacklist">
+                <span>Apply to all websites except those matching patterns below (blacklist)</span>
+            </label>
+        </div>
+        
+        <div class="patterns-section" id="patterns-section" style="display: none;">
+            <h2>Domain Patterns</h2>
+            <p class="info">Enter one regex pattern per line. Examples:</p>
+            <ul class="examples">
+                <li><code>^https://.*\.example\.com/.*</code> - Matches all subdomains of example.com</li>
+                <li><code>^https://github\.com/.*</code> - Matches all GitHub pages</li>
+                <li><code>.*youtube\.com.*</code> - Matches any URL containing youtube.com</li>
+            </ul>
+            <textarea id="patterns" rows="10" placeholder="Enter regex patterns, one per line..."></textarea>
+        </div>
+        
+        <div class="button-group">
+            <button id="save">Save Settings</button>
+            <span id="status"></span>
+        </div>
+    </div>
+    
+    <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,74 @@
+/**
+ * Disable Page Visibility API - Options Page
+ * Copyright (C) 2021 Marvin Schopf
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+// save settings to chrome.storage.sync
+function saveSettings() {
+    const mode = document.querySelector('input[name="mode"]:checked').value;
+    const patterns = document.getElementById('patterns').value
+        .split('\n')
+        .map(p => p.trim())
+        .filter(p => p.length > 0);
+    
+    chrome.storage.sync.set({
+        mode: mode,
+        patterns: patterns
+    }, function() {
+        // show saved status
+        const status = document.getElementById('status');
+        status.textContent = 'Settings saved!';
+        status.style.color = '#4CAF50';
+        setTimeout(function() {
+            status.textContent = '';
+        }, 2000);
+    });
+}
+
+// load settings from chrome.storage.sync
+function loadSettings() {
+    chrome.storage.sync.get({
+        mode: 'all',
+        patterns: []
+    }, function(items) {
+        // set the mode
+        document.getElementById('mode-' + items.mode).checked = true;
+        
+        // set the patterns
+        document.getElementById('patterns').value = items.patterns.join('\n');
+        
+        // show/hide patterns section based on mode
+        updatePatternsVisibility();
+    });
+}
+
+// show/hide the patterns section based on selected mode
+function updatePatternsVisibility() {
+    const mode = document.querySelector('input[name="mode"]:checked').value;
+    const patternsSection = document.getElementById('patterns-section');
+    
+    if (mode === 'whitelist' || mode === 'blacklist') {
+        patternsSection.style.display = 'block';
+    } else {
+        patternsSection.style.display = 'none';
+    }
+}
+
+// initialize when page loads
+document.addEventListener('DOMContentLoaded', function() {
+    loadSettings();
+    
+    // add event listeners
+    document.getElementById('save').addEventListener('click', saveSettings);
+    
+    // add mode change listeners
+    const modeRadios = document.querySelectorAll('input[name="mode"]');
+    modeRadios.forEach(radio => {
+        radio.addEventListener('change', updatePatternsVisibility);
+    });
+});


### PR DESCRIPTION
## Summary
- Added options page for configuring extension behavior
- Users can now choose between three modes: apply to all sites (default), whitelist mode, or blacklist mode
- Domain patterns are specified using regular expressions for flexible matching

## Test plan
- [ ] Install the updated extension
- [ ] Right-click extension icon and select "Options"
- [ ] Test "Apply to all websites" mode - verify extension works on all sites
- [ ] Test whitelist mode with patterns like `.*youtube\.com.*` - verify only works on matching sites
- [ ] Test blacklist mode with patterns - verify works on all sites except matching ones
- [ ] Verify regex validation and error handling for invalid patterns
- [ ] Check that settings persist after browser restart

🤖 Generated with [Claude Code](https://claude.ai/code)